### PR TITLE
 #91 Setup staging environment

### DIFF
--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -1,0 +1,47 @@
+version: "3"
+
+networks:
+  backend:
+
+services:
+  app:
+    build: ./app
+    restart: always
+    expose:
+      - "8080"
+    env_file:
+      - common.env
+    networks:
+      backend:
+        aliases:
+          - app.petandbe.com
+    depends_on:
+      - db
+
+  nginx:
+    image: nginx:1.23.2-alpine
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/staging:/etc/nginx/conf.d
+      - /etc/letsencrypt:/etc/letsencrypt
+    networks:
+      backend:
+    depends_on:
+      - app
+      - db
+  
+  db:
+    image: mysql:8.0
+    restart: always
+    expose:
+      - "3306"
+    env_file:
+      - common.env
+    networks:
+      backend:
+        aliases:
+          - db.petandbe.com

--- a/nginx/staging/staging.conf
+++ b/nginx/staging/staging.conf
@@ -1,0 +1,45 @@
+resolver 127.0.0.11 valid=600s; # default DNS server in docker.
+
+server {
+    listen 80 default_server;
+
+    server_name sg.petandbe.com;
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+
+    server_name sg.petandbe.com;
+
+    # cert
+    ssl_certificate /etc/letsencrypt/live/petandbe.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/petandbe.com/privkey.pem;
+    ssl_session_cache shared:le_nginx_SSL:10m;
+    ssl_session_timeout 1440m;
+    ssl_session_tickets off;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+
+    ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
+
+    include /etc/nginx/mime.types;
+    default_type text/html;
+
+    set $app app.petandbe.com:8080;
+
+    location / {
+        proxy_pass http://$app;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /nginx-healthz {
+        return 200 'status ok';
+    }
+}


### PR DESCRIPTION
#91 

## 변경사항

- 스테이징 환경 구축
  - 스테이징용 docker-compose-staging.yml
  - 스테이징 서버에서 위 docker-compose-staging.yml 사용하도록 ~/.bashrc 파일에 `alias dc=docker-compose -f docker-compose-staging.yml` alias 추가
- nginx 관련 설정
  - https 적용하기 위해 무료 인증기관인 **Let's Encrypt**로 SSL 인증서 발급
  - nginx.conf의 https 관련 설정에 ssl 관련 설정
  - http 요청은 https로 리다이렉션하도록 설정