### PR TITLE
 #95 Add volumes config on DB service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,7 @@ gradle-app.setting
 # mac
 **/.DS_Store
 
+# mysql
+**/mysql
+
 # End of https://www.toptal.com/developers/gitignore/api/java,intellij,gradle

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -41,6 +41,8 @@ services:
       - "3306"
     env_file:
       - common.env
+    volumes:
+      - "./mysql:/var/lib/mysql"
     networks:
       backend:
         aliases:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - "3306"
     env_file:
       - common.env
+    volumes:
+      - "./mysql:/var/lib/mysql"
     networks:
       backend:
         aliases:


### PR DESCRIPTION
#95 

## 변경사항

- `docker-compose.yml` 및 `docker-compose-staging.yml` 파일의 db service에 다음과 같이 volumes 설정 추가

```text
db:
  ...
  volumes:
    - "./mysql:/var/lib/mysql"
  ...
```